### PR TITLE
Allow build-helper:released-version to search in maven central when own version is snapshot

### DIFF
--- a/.maven-settings.xml
+++ b/.maven-settings.xml
@@ -37,9 +37,6 @@
             <enabled>true</enabled>
             <updatePolicy>never</updatePolicy>
           </releases>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
         </repository>
 
         <repository>


### PR DESCRIPTION
I know this basically makes no sense but the helper will not look into central when own version is SNAPSHOT and snapshots are not allowed for central.