### PR TITLE
Use PackageType.MIXED when package has no content type

### DIFF
--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilder.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilder.java
@@ -450,7 +450,11 @@ public final class AllPackageBuilder {
 
                 // if package type is missing package properties, put in the type defined in model
                 if (props.get(NAME_PACKAGE_TYPE) == null) {
-                  props.put(NAME_PACKAGE_TYPE, pkg.getPackageType());
+                  String packageType = pkg.getPackageType();
+                  if (packageType == null) {
+                    packageType = PackageType.MIXED.name();
+                  }
+                  props.put(NAME_PACKAGE_TYPE, packageType);
                 }
 
                 ZipEntry zipOutEntry = new ZipEntry(zipInEntry.getName());


### PR DESCRIPTION
I have tried to fix the NPE by setting "mixed" content type as default.
But there is now another issue

```
 Execution cloudmanager-all-package of goal io.wcm.devops.conga.plugins:conga-aem-maven-plugin:2.16.3-SNAPSHOT:cloudmanager-all-package failed: Package adobe/consulting:acs-aem-commons-content:5.0.10 contains sub package adobe/consulting:acs-aem-commons-ui.content:5.0.10 with invalid package type: ''
```

I do not know the best way how to deal with that. 