### PR TITLE
conga-aem-maven-plugin: Add parameter "embedPackageMode" to be able to switch from embedding packages via /apps folder to /etc/packages folder

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -28,6 +28,9 @@
         conga-aem-maven-plugin: Add parameter "runModeOptimization" to "cloudmanager-all-package" goal, set by default to OFF.
         When set to ELIMINATE_DUPLICATES, only one content package is built per environment, including author and publish runmodes, eliminating duplicates between those two modes as much as possible.
       </action>
+      <action type="add" dev="sseifert"><![CDATA[
+        conga-aem-maven-plugin: Add parameter "embedPackageMode" to be able to switch from embedding packages via /apps folder to /etc/packages folder as workaround for potential issues with AEM 6.5 (like <a href="https://github.com/Netcentric/accesscontroltool/issues/451">this</a>).
+      ]]></action>
     </release>
 
     <release version="2.17.0" date="2022-05-11">

--- a/conga-aem-plugin/pom.xml
+++ b/conga-aem-plugin/pom.xml
@@ -25,13 +25,13 @@
   <parent>
     <groupId>io.wcm.devops.conga.plugins</groupId>
     <artifactId>io.wcm.devops.conga.plugins.aem.parent</artifactId>
-    <version>2.17.1-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
   <groupId>io.wcm.devops.conga.plugins</groupId>
   <artifactId>io.wcm.devops.conga.plugins.aem</artifactId>
-  <version>2.17.1-SNAPSHOT</version>
+  <version>2.18.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CONGA AEM Plugin</name>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>io.wcm.devops.conga.plugins</groupId>
   <artifactId>io.wcm.devops.conga.plugins.aem.parent</artifactId>
-  <version>2.17.1-SNAPSHOT</version>
+  <version>2.18.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>CONGA AEM Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,13 @@
   <parent>
     <groupId>io.wcm.devops.conga.plugins</groupId>
     <artifactId>io.wcm.devops.conga.plugins.aem.parent</artifactId>
-    <version>2.17.1-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 
   <groupId>io.wcm.devops.conga.plugins</groupId>
   <artifactId>io.wcm.devops.conga.plugins.aem.root</artifactId>
-  <version>2.17.1-SNAPSHOT</version>
+  <version>2.18.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>CONGA AEM Plugin</name>

--- a/tooling/conga-aem-crypto-cli/pom.xml
+++ b/tooling/conga-aem-crypto-cli/pom.xml
@@ -25,14 +25,14 @@
   <parent>
     <groupId>io.wcm.devops.conga.plugins</groupId>
     <artifactId>io.wcm.devops.conga.plugins.aem.parent</artifactId>
-    <version>2.17.1-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
   <groupId>io.wcm.devops.conga.plugins</groupId>
   <artifactId>conga-aem-crypto-cli</artifactId>
   <packaging>jar</packaging>
-  <version>2.17.1-SNAPSHOT</version>
+  <version>2.18.0-SNAPSHOT</version>
 
   <name>CONGA AEM Crypto Command Line Interface</name>
   <description>Command line tool to generate Crypto keys for AEM.</description>
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>io.wcm.devops.conga.plugins</groupId>
       <artifactId>io.wcm.devops.conga.plugins.aem</artifactId>
-      <version>2.17.1-SNAPSHOT</version>
+      <version>2.18.0-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <!-- Exclude all deps - only crypto util classes are used -->

--- a/tooling/conga-aem-maven-plugin/pom.xml
+++ b/tooling/conga-aem-maven-plugin/pom.xml
@@ -25,14 +25,14 @@
   <parent>
     <groupId>io.wcm.devops.conga.plugins</groupId>
     <artifactId>io.wcm.devops.conga.plugins.aem.parent</artifactId>
-    <version>2.17.1-SNAPSHOT</version>
+    <version>2.18.0-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
   <groupId>io.wcm.devops.conga.plugins</groupId>
   <artifactId>conga-aem-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>2.17.1-SNAPSHOT</version>
+  <version>2.18.0-SNAPSHOT</version>
 
   <name>CONGA AEM Maven Plugin</name>
   <description>wcm.io DevOps CONGA - CONfiguration GenerAtor Maven Plugin for AEM</description>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>io.wcm.devops.conga.plugins</groupId>
       <artifactId>io.wcm.devops.conga.plugins.aem</artifactId>
-      <version>2.17.1-SNAPSHOT</version>
+      <version>2.18.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/tooling/conga-aem-maven-plugin/src/it/example/pom.xml
+++ b/tooling/conga-aem-maven-plugin/src/it/example/pom.xml
@@ -141,6 +141,19 @@
               <target>${project.build.directory}/all/single</target>
             </configuration>
           </execution>
+          <execution>
+            <id>all-embed-subpackages</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>cloudmanager-all-package</goal>
+            </goals>
+            <configuration>
+              <group>it</group>
+              <embedPackageMode>SUB_PACKAGE</embedPackageMode>
+              <packageTypeValidation>WARN</packageTypeValidation>
+              <target>${project.build.directory}/all/embed-subpackages</target>
+            </configuration>
+          </execution>
 
         </executions>
       </plugin>

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/CloudManagerAllPackageMojo.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/CloudManagerAllPackageMojo.java
@@ -131,6 +131,22 @@ public final class CloudManagerAllPackageMojo extends AbstractCloudManagerMojo {
   private PackageTypeValidation packageTypeValidation;
 
   /**
+   * How to embed packages in the "all" package.
+   * <p>
+   * Possible values:
+   * </p>
+   * <ul>
+   * <li><code>EMBED</code>: Includes content packages via /apps folder, to be picked up by OSGi installer.
+   * This is the recommended way and mandatory for AEMaaCS.</li>
+   * <li><code>SUB_PACKAGE</code>: Includes content packages via /etc/packages folder, to be picked up by Package
+   * Manager. This is an alternative mode for AEM 6.5 and below if you encounter issues with OSGi installer
+   * (like <a href="https://github.com/Netcentric/accesscontroltool/issues/451">this</a>).</li>
+   * </ul>
+   */
+  @Parameter(property = "conga.cloudManager.allPackage.embedPackageMode", defaultValue = "EMBED")
+  private EmbedPackageMode embedPackageMode;
+
+  /**
    * Automatically generate dependencies between content packages based on file order in CONGA configuration.
    * @deprecated Please use autoDependenciesMode instead.
    */
@@ -264,6 +280,7 @@ public final class CloudManagerAllPackageMojo extends AbstractCloudManagerMojo {
         .autoDependenciesMode(this.autoDependenciesMode)
         .runModeOptimization(this.runModeOptimization)
         .packageTypeValidation(this.packageTypeValidation)
+        .embedPackageMode(this.embedPackageMode)
         .logger(getLog());
   }
 

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/CloudManagerAllPackageMojo.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/CloudManagerAllPackageMojo.java
@@ -140,7 +140,8 @@ public final class CloudManagerAllPackageMojo extends AbstractCloudManagerMojo {
    * This is the recommended way and mandatory for AEMaaCS.</li>
    * <li><code>SUB_PACKAGE</code>: Includes content packages via /etc/packages folder, to be picked up by Package
    * Manager. This is an alternative mode for AEM 6.5 and below if you encounter issues with OSGi installer
-   * (like <a href="https://github.com/Netcentric/accesscontroltool/issues/451">this</a>).</li>
+   * (like <a href="https://github.com/Netcentric/accesscontroltool/issues/451">this</a>).
+   * This mode cannot be used with "singlePackage" mode or with runModeOptimization=ELEMINATE_DUPLICATES.</li>
    * </ul>
    */
   @Parameter(property = "conga.cloudManager.allPackage.embedPackageMode", defaultValue = "EMBED")
@@ -199,6 +200,13 @@ public final class CloudManagerAllPackageMojo extends AbstractCloudManagerMojo {
       else {
         this.autoDependenciesMode = AutoDependenciesMode.OFF;
       }
+    }
+
+    // validate parameters
+    if (embedPackageMode == EmbedPackageMode.SUB_PACKAGE
+        && (singlePackage || runModeOptimization == RunModeOptimization.ELIMINATE_DUPLICATES)) {
+      throw new MojoFailureException("embedPackageMode=SUB_PACKAGE is not compatible with singlePackage mode "
+          + "or runModeOptimization=ELIMINATE_DUPLICATES.");
     }
 
     if (singlePackage) {

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/EmbedPackageMode.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/EmbedPackageMode.java
@@ -1,0 +1,40 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.devops.conga.plugins.aem.maven;
+
+/**
+ * How to embed packages in the "all" package.
+ */
+public enum EmbedPackageMode {
+
+  /**
+   * Includes content packages via /apps folder, to be picked up by OSGi installer.
+   * This is the recommended way and mandatory for AEMaaCS.
+   */
+  EMBED,
+
+  /**
+   * Includes content packages via /etc/packages folder, to be picked up by Package Manager.
+   * This is an alternative mode for AEM 6.5 and below if you encounter issues with OSGi installer
+   * (like <a href="https://github.com/Netcentric/accesscontroltool/issues/451">this</a>).
+   */
+  SUB_PACKAGE
+
+}

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/EmbedPackageMode.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/EmbedPackageMode.java
@@ -34,6 +34,7 @@ public enum EmbedPackageMode {
    * Includes content packages via /etc/packages folder, to be picked up by Package Manager.
    * This is an alternative mode for AEM 6.5 and below if you encounter issues with OSGi installer
    * (like <a href="https://github.com/Netcentric/accesscontroltool/issues/451">this</a>).
+   * This mode cannot be used with "singlePackage" mode or with runModeOptimization=ELEMINATE_DUPLICATES.
    */
   SUB_PACKAGE
 

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilder.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilder.java
@@ -482,7 +482,7 @@ public final class AllPackageBuilder {
     if (embedPackageMode == EmbedPackageMode.SUB_PACKAGE) {
       // in SUB_PACKAGE mode all packages are stored in the /etc/packages/xxx folder - it's not possible to assign any run modes
       // that's why that mode is not supported in singlePackage mode or with runModeOptimizatin=ELIMINATE_DUPLICATES
-      parentPath = rootPath;
+      parentPath = rootPath + '/' + pkg.getGroup();
     }
     else {
       // add run mode suffix to both install folder path and package file name

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilder.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilder.java
@@ -65,6 +65,7 @@ import org.jetbrains.annotations.Nullable;
 import com.google.common.collect.ImmutableSet;
 
 import io.wcm.devops.conga.plugins.aem.maven.AutoDependenciesMode;
+import io.wcm.devops.conga.plugins.aem.maven.EmbedPackageMode;
 import io.wcm.devops.conga.plugins.aem.maven.PackageTypeValidation;
 import io.wcm.devops.conga.plugins.aem.maven.RunModeOptimization;
 import io.wcm.devops.conga.plugins.aem.maven.model.BundleFile;
@@ -104,6 +105,7 @@ public final class AllPackageBuilder {
   private AutoDependenciesMode autoDependenciesMode = AutoDependenciesMode.OFF;
   private RunModeOptimization runModeOptimization = RunModeOptimization.OFF;
   private PackageTypeValidation packageTypeValidation = PackageTypeValidation.STRICT;
+  private EmbedPackageMode embedPackageMode = EmbedPackageMode.EMBED;
   private Log log;
 
   private static final String RUNMODE_DEFAULT = "$default$";
@@ -151,6 +153,15 @@ public final class AllPackageBuilder {
    */
   public AllPackageBuilder packageTypeValidation(PackageTypeValidation value) {
     this.packageTypeValidation = value;
+    return this;
+  }
+
+  /**
+   * @param value How to embed packages in the "all" package.
+   * @return this
+   */
+  public AllPackageBuilder embedPackageMode(EmbedPackageMode value) {
+    this.embedPackageMode = value;
     return this;
   }
 
@@ -301,7 +312,7 @@ public final class AllPackageBuilder {
     }
 
     // define root path for "all" package
-    String rootPath = buildRootPath(groupName, packageName);
+    String rootPath = buildContentPackageRootPath(groupName, packageName, embedPackageMode);
     builder.filter(new PackageFilter(rootPath));
 
     // additional package properties
@@ -435,13 +446,22 @@ public final class AllPackageBuilder {
   }
 
   /**
-   * Build root path to be used for embedded package.
+   * Build root path to be used for embedded packages / sub packages.
    * @param groupName Group name
    * @param packageName Package name
+   * @param embedPackageMode Embed package mode
    * @return Package path
    */
-  private static String buildRootPath(String groupName, String packageName) {
-    return "/apps/" + groupName + "-" + packageName + "-packages";
+  private static String buildContentPackageRootPath(String groupName, String packageName,
+      EmbedPackageMode embedPackageMode) {
+    switch (embedPackageMode) {
+      case EMBED:
+        return "/apps/" + groupName + "-" + packageName + "-packages";
+      case SUB_PACKAGE:
+        return "/etc/packages/" + groupName + "-" + packageName;
+      default:
+        throw new IllegalArgumentException("Unsupported embed package mode: " + embedPackageMode);
+    }
   }
 
   /**

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/RootPaths.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/RootPaths.java
@@ -1,0 +1,100 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.devops.conga.plugins.aem.maven.allpackage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.wcm.devops.conga.plugins.aem.maven.EmbedPackageMode;
+
+/**
+ * Manages root paths inside "all" package.
+ */
+class RootPaths {
+
+  private final String contentPackagesRootPath;
+  private final String bundlesRootPath;
+
+  RootPaths(String groupName, String packageName, EmbedPackageMode embedPackageMode) {
+    this.bundlesRootPath = buildEmbedRootPath(groupName, packageName);
+    switch (embedPackageMode) {
+      case EMBED:
+        this.contentPackagesRootPath = this.bundlesRootPath;
+        break;
+      case SUB_PACKAGE:
+        this.contentPackagesRootPath = buildSubPackageRootPath(groupName, packageName);
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid embed package mode: " + embedPackageMode);
+    }
+  }
+
+  public String getContentPackagesRootPath() {
+    return this.contentPackagesRootPath;
+  }
+
+  public String getBundlesRootPath() {
+    return this.bundlesRootPath;
+  }
+
+  /**
+   * Get list of actually used root paths in "all" packages (for package filter).
+   * @param contentPackageFileSets Content package file sets
+   * @param bundleFileSets Bundle file sets
+   * @return Root Paths
+   */
+  public List<String> getActualUsedRootPaths(
+      List<ContentPackageFileSet> contentPackageFileSets, List<BundleFileSet> bundleFileSets) {
+    List<String> result = new ArrayList<>();
+    if (hasAnyFile(contentPackageFileSets)) {
+      result.add(this.contentPackagesRootPath);
+    }
+    if (hasAnyFile(bundleFileSets)) {
+      result.add(this.bundlesRootPath);
+    }
+    return result;
+  }
+
+  private boolean hasAnyFile(List<? extends FileSet> fileSets) {
+    return fileSets.stream()
+        .anyMatch(fileSet -> !fileSet.getFiles().isEmpty());
+  }
+
+  /**
+   * Build root path to be used for embedded packages/bundles in /apps.
+   * @param groupName Group name
+   * @param packageName Package name
+   * @return Package path
+   */
+  private static String buildEmbedRootPath(String groupName, String packageName) {
+    return "/apps/" + groupName + "-" + packageName + "-packages";
+  }
+
+  /**
+   * Build root path to be used for sub packages in /etc/packages.
+   * @param groupName Group name
+   * @param packageName Package name
+   * @return Package path
+   */
+  private static String buildSubPackageRootPath(String groupName, String packageName) {
+    return "/etc/packages/" + groupName + "-" + packageName;
+  }
+
+}

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/RootPaths.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/RootPaths.java
@@ -29,6 +29,9 @@ import io.wcm.devops.conga.plugins.aem.maven.EmbedPackageMode;
  */
 class RootPaths {
 
+  @SuppressWarnings("java:S1075") // fixed repository path
+  private static final String ETC_PACKAGES_PATH = "/etc/packages";
+
   private final String contentPackagesRootPath;
   private final String bundlesRootPath;
 
@@ -39,7 +42,7 @@ class RootPaths {
         this.contentPackagesRootPath = this.bundlesRootPath;
         break;
       case SUB_PACKAGE:
-        this.contentPackagesRootPath = buildSubPackageRootPath(groupName, packageName);
+        this.contentPackagesRootPath = ETC_PACKAGES_PATH;
         break;
       default:
         throw new IllegalArgumentException("Invalid embed package mode: " + embedPackageMode);
@@ -63,12 +66,19 @@ class RootPaths {
   public List<String> getActualUsedRootPaths(
       List<ContentPackageFileSet> contentPackageFileSets, List<BundleFileSet> bundleFileSets) {
     List<String> result = new ArrayList<>();
+
+    // TODO: DANGER - this would include /etc/packages in the filter list - not a good idea
+    /*
     if (hasAnyFile(contentPackageFileSets)) {
       result.add(this.contentPackagesRootPath);
     }
     if (hasAnyFile(bundleFileSets)) {
       result.add(this.bundlesRootPath);
     }
+    */
+
+    result.add(this.bundlesRootPath);
+
     return result;
   }
 
@@ -85,16 +95,6 @@ class RootPaths {
    */
   private static String buildEmbedRootPath(String groupName, String packageName) {
     return "/apps/" + groupName + "-" + packageName + "-packages";
-  }
-
-  /**
-   * Build root path to be used for sub packages in /etc/packages.
-   * @param groupName Group name
-   * @param packageName Package name
-   * @return Package path
-   */
-  private static String buildSubPackageRootPath(String groupName, String packageName) {
-    return "/etc/packages/" + groupName + "-" + packageName;
   }
 
 }

--- a/tooling/conga-aem-maven-plugin/src/test/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilderEmbedModeTest.java
+++ b/tooling/conga-aem-maven-plugin/src/test/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilderEmbedModeTest.java
@@ -69,31 +69,41 @@ class AllPackageBuilderEmbedModeTest {
 
     ZipUtil.unpack(targetFile, targetUnpackDir);
 
-    File packagesDir = new File(targetUnpackDir, "jcr_root/etc/packages/test-group-test-pkg");
-    assertTrue(packagesDir.exists(), "dir exists: " + packagesDir.getPath());
+    File packagesDir = new File(targetUnpackDir, "jcr_root/etc/packages");
+    assertDirectories(packagesDir, "sample", "adobe", "Netcentric");
 
-    File appsDir = new File(targetUnpackDir, "jcr_root/apps/test-group-test-pkg-packages");
-    assertDirectories(appsDir, "application");
-
-    assertFiles(packagesDir, ".author",
-        contentPackage("accesscontroltool-apps-package{runmode}", "3.0.0"),
-        contentPackage("accesscontroltool-oakindex-package{runmode}", "3.0.0"),
-        contentPackage("core.wcm.components.content{runmode}", "2.17.0",
-            dep("day/cq60/product:cq-platform-content:1.3.248")),
-        contentPackage("core.wcm.components.extensions.amp.content{runmode}", "2.17.0"),
-        contentPackage("acs-aem-commons-ui.apps{runmode}", "4.10.0",
-            dep("day/cq60/product:cq-content:6.3.64")),
+    File packagesDirSample = new File(packagesDir, "sample");
+    assertFiles(packagesDirSample, ".author",
         contentPackage("aem-cms-system-config{runmode}",
             dep("day/cq60/product:cq-ui-wcm-editor-content:1.1.224"),
             dep("adobe/cq/product:cq-remotedam-client-ui-components:1.1.6")),
-        contentPackage("acs-aem-commons-ui.content{runmode}", "4.10.0"),
         contentPackage("aem-cms-author-replicationagents{runmode}"),
         contentPackage("wcm-io-samples-sample-content{runmode}", "1.3.1-SNAPSHOT"),
-        contentPackage("accesscontroltool-package{runmode}", "3.0.0"),
-        contentPackage("core.wcm.components.all{runmode}", "2.17.0"),
-        contentPackage("core.wcm.components.config{runmode}", "2.17.0"),
         contentPackage("wcm-io-samples-aem-cms-config{runmode}"),
         contentPackage("wcm-io-samples-complete{runmode}", "1.3.1-SNAPSHOT"));
+
+    File packagesDirAdobeCoreComponents = new File(packagesDir, "adobe/cq60");
+    assertFiles(packagesDirAdobeCoreComponents, ".author",
+        contentPackage("core.wcm.components.content{runmode}", "2.17.0",
+            dep("day/cq60/product:cq-platform-content:1.3.248")),
+        contentPackage("core.wcm.components.extensions.amp.content{runmode}", "2.17.0"),
+        contentPackage("core.wcm.components.all{runmode}", "2.17.0"),
+        contentPackage("core.wcm.components.config{runmode}", "2.17.0"));
+
+    File packagesDirAdobeConsulting = new File(packagesDir, "adobe/consulting");
+    assertFiles(packagesDirAdobeConsulting, ".author",
+        contentPackage("acs-aem-commons-ui.apps{runmode}", "4.10.0",
+            dep("day/cq60/product:cq-content:6.3.64")),
+        contentPackage("acs-aem-commons-ui.content{runmode}", "4.10.0"));
+
+    File packagesDirNetcentric = new File(packagesDir, "Netcentric");
+    assertFiles(packagesDirNetcentric, ".author",
+        contentPackage("accesscontroltool-apps-package{runmode}", "3.0.0"),
+        contentPackage("accesscontroltool-oakindex-package{runmode}", "3.0.0"),
+        contentPackage("accesscontroltool-package{runmode}", "3.0.0"));
+
+    File appsDir = new File(targetUnpackDir, "jcr_root/apps/test-group-test-pkg-packages");
+    assertDirectories(appsDir, "application");
 
     File applicationDir = new File(appsDir, "application");
     assertDirectories(applicationDir, "install.author");

--- a/tooling/conga-aem-maven-plugin/src/test/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilderEmbedModeTest.java
+++ b/tooling/conga-aem-maven-plugin/src/test/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilderEmbedModeTest.java
@@ -1,0 +1,107 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.devops.conga.plugins.aem.maven.allpackage;
+
+import static io.wcm.devops.conga.plugins.aem.maven.allpackage.FileTestUtil.assertDirectories;
+import static io.wcm.devops.conga.plugins.aem.maven.allpackage.FileTestUtil.assertFiles;
+import static io.wcm.devops.conga.plugins.aem.maven.allpackage.FileTestUtil.contentPackage;
+import static io.wcm.devops.conga.plugins.aem.maven.allpackage.FileTestUtil.dep;
+import static io.wcm.devops.conga.plugins.aem.maven.allpackage.FileTestUtil.file;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.zeroturnaround.zip.ZipUtil;
+
+import io.wcm.devops.conga.plugins.aem.maven.EmbedPackageMode;
+import io.wcm.devops.conga.plugins.aem.maven.model.InstallableFile;
+import io.wcm.devops.conga.plugins.aem.maven.model.ModelParser;
+
+class AllPackageBuilderEmbedModeTest {
+
+  private File nodeDir;
+  private File targetDir;
+  private File targetUnpackDir;
+
+  @BeforeEach
+  void setUp(TestInfo testInfo) throws IOException {
+    nodeDir = new File("src/test/resources/node/aem-author");
+    targetDir = new File("target/test-" + getClass().getSimpleName() + "_" + testInfo.getDisplayName());
+    targetUnpackDir = new File(targetDir, "unpack");
+    FileUtils.deleteDirectory(targetDir);
+    targetDir.mkdirs();
+    targetUnpackDir.mkdirs();
+  }
+
+  @Test
+  void testBuild_EMBED_MODE_SUB_PACKAGES() throws Exception {
+    List<InstallableFile> files = new ModelParser(nodeDir).getInstallableFilesForNode();
+    File targetFile = new File(targetDir, "all.zip");
+
+    AllPackageBuilder builder = new AllPackageBuilder(targetFile, "test-group", "test-pkg")
+        .embedPackageMode(EmbedPackageMode.SUB_PACKAGE);
+    builder.add(files, Collections.emptySet());
+    assertTrue(builder.build(null));
+
+    ZipUtil.unpack(targetFile, targetUnpackDir);
+
+    File packagesDir = new File(targetUnpackDir, "jcr_root/etc/packages/test-group-test-pkg");
+    assertTrue(packagesDir.exists(), "dir exists: " + packagesDir.getPath());
+
+    File appsDir = new File(targetUnpackDir, "jcr_root/apps/test-group-test-pkg-packages");
+    assertDirectories(appsDir, "application");
+
+    assertFiles(packagesDir, ".author",
+        contentPackage("accesscontroltool-apps-package{runmode}", "3.0.0"),
+        contentPackage("accesscontroltool-oakindex-package{runmode}", "3.0.0"),
+        contentPackage("core.wcm.components.content{runmode}", "2.17.0",
+            dep("day/cq60/product:cq-platform-content:1.3.248")),
+        contentPackage("core.wcm.components.extensions.amp.content{runmode}", "2.17.0"),
+        contentPackage("acs-aem-commons-ui.apps{runmode}", "4.10.0",
+            dep("day/cq60/product:cq-content:6.3.64")),
+        contentPackage("aem-cms-system-config{runmode}",
+            dep("day/cq60/product:cq-ui-wcm-editor-content:1.1.224"),
+            dep("adobe/cq/product:cq-remotedam-client-ui-components:1.1.6")),
+        contentPackage("acs-aem-commons-ui.content{runmode}", "4.10.0"),
+        contentPackage("aem-cms-author-replicationagents{runmode}"),
+        contentPackage("wcm-io-samples-sample-content{runmode}", "1.3.1-SNAPSHOT"),
+        contentPackage("accesscontroltool-package{runmode}", "3.0.0"),
+        contentPackage("core.wcm.components.all{runmode}", "2.17.0"),
+        contentPackage("core.wcm.components.config{runmode}", "2.17.0"),
+        contentPackage("wcm-io-samples-aem-cms-config{runmode}"),
+        contentPackage("wcm-io-samples-complete{runmode}", "1.3.1-SNAPSHOT"));
+
+    File applicationDir = new File(appsDir, "application");
+    assertDirectories(applicationDir, "install.author");
+
+    File applicationInstallDirAuthor = new File(applicationDir, "install.author");
+    assertFiles(applicationInstallDirAuthor, ".author",
+        file("io.wcm.caconfig.editor-1.11.0.jar"),
+        file("io.wcm.wcm.ui.granite-1.9.2.jar"));
+  }
+
+}

--- a/tooling/conga-aem-maven-plugin/src/test/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/FileTestUtil.java
+++ b/tooling/conga-aem-maven-plugin/src/test/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/FileTestUtil.java
@@ -116,7 +116,7 @@ public final class FileTestUtil {
    * @param fileNames Expected file names in directory
    */
   public static void assertDirectories(File dir, String... fileNames) {
-    assertTrue(dir.exists(), "file exists: " + dir.getPath());
+    assertTrue(dir.exists(), "directory exists: " + dir.getPath());
     assertTrue(dir.isDirectory(), "is directory: " + dir.getPath());
     Set<String> expectedDirectoryNames = ImmutableSet.copyOf(fileNames);
     Set<String> actualDirectoryNames = Collections.emptySet();


### PR DESCRIPTION
 as workaround for potential issues with AEM 6.5