### PR TITLE
Add version suffix to release version packages (configurable)

### DIFF
--- a/tooling/conga-aem-maven-plugin/src/it/wcmio-archetype-aem65/config-definition/pom.xml
+++ b/tooling/conga-aem-maven-plugin/src/it/wcmio-archetype-aem65/config-definition/pom.xml
@@ -94,6 +94,28 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <groupId>io.wcm.devops.conga.plugins</groupId>
+        <artifactId>conga-aem-maven-plugin</artifactId>
+        <executions>
+
+          <!-- Generate "all" packages including all packages from CONGA configuration for deployment via Adobe Cloud Manager -->
+          <execution>
+            <id>cloudmanager-all-package</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>cloudmanager-all-package</goal>
+            </goals>
+            <configuration>
+              <group>it</group>
+              <packageTypeValidation>WARN</packageTypeValidation>
+              <packageVersionMode>RELEASE_SUFFIX_VERSION</packageVersionMode>
+            </configuration>
+          </execution>
+
+        </executions>
+      </plugin>
+
       <!-- Do not generate eclipse project files -->
       <plugin>
         <groupId>io.wcm.devops.maven.plugins</groupId>

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/CloudManagerAllPackageMojo.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/CloudManagerAllPackageMojo.java
@@ -131,6 +131,16 @@ public final class CloudManagerAllPackageMojo extends AbstractCloudManagerMojo {
   private PackageTypeValidation packageTypeValidation;
 
   /**
+   * How to handle versions of packages and sub-packages inside "all" package.
+   * <p>
+   * Possible options see
+   * <a href="apidocs/io/wcm/devops/conga/plugins/aem/maven/PackageVersionMode.html">PackageVersionMode</a>.
+   * </p>
+   */
+  @Parameter(property = "conga.cloudManager.allPackage.packageVersionMode", defaultValue = "DEFAULT")
+  private PackageVersionMode packageVersionMode;
+
+  /**
    * Automatically generate dependencies between content packages based on file order in CONGA configuration.
    * @deprecated Please use autoDependenciesMode instead.
    */
@@ -267,6 +277,7 @@ public final class CloudManagerAllPackageMojo extends AbstractCloudManagerMojo {
         .autoDependenciesMode(this.autoDependenciesMode)
         .runModeOptimization(this.runModeOptimization)
         .packageTypeValidation(this.packageTypeValidation)
+        .packageVersionMode(this.packageVersionMode)
         .logger(getLog())
         .buildOutputTimestamp(new BuildOutputTimestamp(outputTimestamp));
   }

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/PackageVersionMode.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/PackageVersionMode.java
@@ -31,13 +31,14 @@ public enum PackageVersionMode {
 
   /**
    * Suffix the version number of all packages with a release version with the version of the POM the Mojo runs in.
+   * Within the version suffix, dots are replaced with underlines to avoid convision with the main version number.
    * This is useful when deploying to AMS with Cloud Manager.
    * <p>
    * Example:
    * </p>
    * <ul>
    * <li>Original package version: 2.5.0</li>
-   * <li>POM version: 2022_1103_152749_0000000571</li>
+   * <li>POM version: 2022.1103.152749.0000000571</li>
    * <li>Resulting package version: 2.5.0-2022_1103_152749_0000000571</li>
    * </ul>
    */

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/PackageVersionMode.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/PackageVersionMode.java
@@ -1,0 +1,46 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.devops.conga.plugins.aem.maven;
+
+/**
+ * How to handle versions of packages and sub-packages inside "all" package.
+ */
+public enum PackageVersionMode {
+
+  /**
+   * Keep original versions.
+   */
+  DEFAULT,
+
+  /**
+   * Suffix the version number of all packages with a release version with the version of the POM the Mojo runs in.
+   * This is useful when deploying to AMS with Cloud Manager.
+   * <p>
+   * Example:
+   * </p>
+   * <ul>
+   * <li>Original package version: 2.5.0</li>
+   * <li>POM version: 2022_1103_152749_0000000571</li>
+   * <li>Resulting package version: 2.5.0-2022_1103_152749_0000000571</li>
+   * </ul>
+   */
+  RELEASE_SUFFIX_VERSION
+
+}

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilder.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilder.java
@@ -491,13 +491,14 @@ public final class AllPackageBuilder {
   /**
    * Generate suffix for versions of content packages.
    * @param pkg Content package
+   * @param ignoreSnapshot Do not build version suffix for SNAPSHOT versions
    * @return Suffix string
    */
-  private String buildVersionSuffix(ContentPackageFile pkg) {
+  private String buildVersionSuffix(ContentPackageFile pkg, boolean ignoreSnapshot) {
     StringBuilder versionSuffix = new StringBuilder();
 
     if (this.packageVersionMode == PackageVersionMode.RELEASE_SUFFIX_VERSION
-        && !ArtifactUtils.isSnapshot(pkg.getVersion())
+        && (!ArtifactUtils.isSnapshot(pkg.getVersion()) || !ignoreSnapshot)
         && this.version != null) {
       versionSuffix.append(VERSION_SUFFIX_SEPARATOR)
           // replace dots with underlines in version suffix to avoid confusion with main version number
@@ -527,7 +528,7 @@ public final class AllPackageBuilder {
     String packageVersion = pkg.getVersion();
     String packageVersionWithoutSuffix = packageVersion;
     if (this.packageVersionMode == PackageVersionMode.RELEASE_SUFFIX_VERSION && this.version != null) {
-      packageVersionWithoutSuffix = StringUtils.removeEnd(packageVersion, buildVersionSuffix(pkg));
+      packageVersionWithoutSuffix = StringUtils.removeEnd(packageVersion, buildVersionSuffix(pkg, false));
     }
     if (packageVersion != null && pkg.getFile().getName().contains(packageVersionWithoutSuffix)) {
       versionSuffix = "-" + packageVersion;
@@ -696,7 +697,7 @@ public final class AllPackageBuilder {
     Dependency[] deps;
     if (dependencyFile != null) {
       String runModeSuffix = buildRunModeSuffix(dependencyFile, environmentRunMode);
-      String dependencyVersion = dependencyFile.getVersion() + buildVersionSuffix(dependencyFile);
+      String dependencyVersion = dependencyFile.getVersion() + buildVersionSuffix(dependencyFile, true);
       Dependency newDependency = new Dependency(dependencyFile.getGroup(),
           dependencyFile.getName() + runModeSuffix,
           VersionRange.fromString(dependencyVersion));
@@ -732,7 +733,7 @@ public final class AllPackageBuilder {
     if (StringUtils.isEmpty(pkg.getVersion())) {
       return;
     }
-    String suffixedVersion = pkg.getVersion() + buildVersionSuffix(pkg);
+    String suffixedVersion = pkg.getVersion() + buildVersionSuffix(pkg, true);
     props.put(NAME_VERSION, suffixedVersion);
   }
 

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilder.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilder.java
@@ -527,7 +527,7 @@ public final class AllPackageBuilder {
     String packageVersion = pkg.getVersion();
     String packageVersionWithoutSuffix = packageVersion;
     if (this.packageVersionMode == PackageVersionMode.RELEASE_SUFFIX_VERSION && this.version != null) {
-      packageVersionWithoutSuffix = StringUtils.substringBefore(packageVersion, buildVersionSuffix(pkg));
+      packageVersionWithoutSuffix = StringUtils.removeEnd(packageVersion, buildVersionSuffix(pkg));
     }
     if (packageVersion != null && pkg.getFile().getName().contains(packageVersionWithoutSuffix)) {
       versionSuffix = "-" + packageVersion;
@@ -682,7 +682,7 @@ public final class AllPackageBuilder {
    * @param dependencyFile Dependency package
    * @param allPackagesFromFileSets Set with all packages from all file sets as dependency instances
    */
-  private static void updateDependencies(Properties props, ContentPackageFile dependencyFile, String environmentRunMode,
+  private void updateDependencies(Properties props, ContentPackageFile dependencyFile, String environmentRunMode,
       Set<Dependency> allPackagesFromFileSets) {
     String[] existingDepsStrings = StringUtils.split(props.getProperty(NAME_DEPENDENCIES), ",");
     Dependency[] existingDeps = null;
@@ -696,9 +696,10 @@ public final class AllPackageBuilder {
     Dependency[] deps;
     if (dependencyFile != null) {
       String runModeSuffix = buildRunModeSuffix(dependencyFile, environmentRunMode);
+      String dependencyVersion = dependencyFile.getVersion() + buildVersionSuffix(dependencyFile);
       Dependency newDependency = new Dependency(dependencyFile.getGroup(),
           dependencyFile.getName() + runModeSuffix,
-          VersionRange.fromString(dependencyFile.getVersion()));
+          VersionRange.fromString(dependencyVersion));
       deps = addDependency(existingDeps, newDependency);
     }
     else {

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilder.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilder.java
@@ -499,7 +499,9 @@ public final class AllPackageBuilder {
     if (this.packageVersionMode == PackageVersionMode.RELEASE_SUFFIX_VERSION
         && !ArtifactUtils.isSnapshot(pkg.getVersion())
         && this.version != null) {
-      versionSuffix.append(VERSION_SUFFIX_SEPARATOR).append(this.version);
+      versionSuffix.append(VERSION_SUFFIX_SEPARATOR)
+          // replace dots with underlines in version suffix to avoid confusion with main version number
+          .append(StringUtils.replace(this.version, ".", "_"));
     }
 
     return versionSuffix.toString();
@@ -525,7 +527,7 @@ public final class AllPackageBuilder {
     String packageVersion = pkg.getVersion();
     String packageVersionWithoutSuffix = packageVersion;
     if (this.packageVersionMode == PackageVersionMode.RELEASE_SUFFIX_VERSION && this.version != null) {
-      packageVersionWithoutSuffix = StringUtils.substringBefore(packageVersion, VERSION_SUFFIX_SEPARATOR + this.version);
+      packageVersionWithoutSuffix = StringUtils.substringBefore(packageVersion, buildVersionSuffix(pkg));
     }
     if (packageVersion != null && pkg.getFile().getName().contains(packageVersionWithoutSuffix)) {
       versionSuffix = "-" + packageVersion;

--- a/tooling/conga-aem-maven-plugin/src/test/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilderPackageVersionModeTest.java
+++ b/tooling/conga-aem-maven-plugin/src/test/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilderPackageVersionModeTest.java
@@ -208,4 +208,79 @@ class AllPackageBuilderPackageVersionModeTest {
     }
   }
 
+  @Test
+  void testBuild_RELEASE_SUFFIX_VERSION_SNAPSHOT() throws Exception {
+    List<InstallableFile> files = new ModelParser(nodeDir).getInstallableFilesForNode();
+    List<String> runmodeSuffixes = Collections.singletonList(".author");
+    File targetFile = new File(targetDir, "all.zip");
+
+    AllPackageBuilder builder = new AllPackageBuilder(targetFile, "test-group", "test-pkg")
+        .autoDependenciesMode(AutoDependenciesMode.IMMUTABLE_MUTABLE_SEPARATE)
+        .packageVersionMode(PackageVersionMode.RELEASE_SUFFIX_VERSION)
+        .version("99.99-SNAPSHOT");
+    builder.add(files, Collections.emptySet());
+    assertTrue(builder.build(null));
+
+    ZipUtil.unpack(targetFile, targetUnpackDir);
+
+    File appsDir = new File(targetUnpackDir, "jcr_root/apps/test-group-test-pkg-packages");
+    assertDirectories(appsDir, "application", "content", "container");
+
+    File applicationDir = new File(appsDir, "application");
+    assertDirectories(applicationDir, toInstallFolderNames("install", runmodeSuffixes));
+
+    for (String runmodeSuffix : runmodeSuffixes) {
+      File applicationInstallDir = new File(applicationDir, "install" + runmodeSuffix);
+      assertFiles(applicationInstallDir, runmodeSuffix,
+          contentPackage("accesscontroltool-apps-package{runmode}", "3.0.0-99_99-SNAPSHOT",
+              dep("adobe/consulting:acs-aem-commons-ui.apps{runmode}:4.10.0-99_99-SNAPSHOT")),
+          contentPackage("accesscontroltool-oakindex-package{runmode}", "3.0.0-99_99-SNAPSHOT",
+              dep("Netcentric:accesscontroltool-package{runmode}:3.0.0-99_99-SNAPSHOT")),
+          contentPackage("core.wcm.components.content{runmode}", "2.17.0-99_99-SNAPSHOT",
+              dep("day/cq60/product:cq-platform-content:1.3.248"),
+              dep("Netcentric:accesscontroltool-oakindex-package{runmode}:3.0.0-99_99-SNAPSHOT")),
+          contentPackage("core.wcm.components.extensions.amp.content{runmode}", "2.17.0-99_99-SNAPSHOT",
+              dep("Netcentric:accesscontroltool-oakindex-package{runmode}:3.0.0-99_99-SNAPSHOT")),
+          contentPackage("acs-aem-commons-ui.apps{runmode}", "4.10.0-99_99-SNAPSHOT",
+              dep("day/cq60/product:cq-content:6.3.64")),
+          contentPackage("aem-cms-system-config{runmode}",
+              dep("day/cq60/product:cq-ui-wcm-editor-content:1.1.224"),
+              dep("adobe/cq/product:cq-remotedam-client-ui-components:1.1.6"),
+              dep("adobe/cq60:core.wcm.components.all{runmode}:2.17.0-99_99-SNAPSHOT")),
+          file("io.wcm.caconfig.editor-1.11.0.jar"),
+          file("io.wcm.wcm.ui.granite-1.9.2.jar"));
+    }
+
+    File contentDir = new File(appsDir, "content");
+    assertDirectories(contentDir, toInstallFolderNames("install", runmodeSuffixes));
+
+    for (String runmodeSuffix : runmodeSuffixes) {
+      File contentInstallDir = new File(contentDir, "install" + runmodeSuffix);
+      assertFiles(contentInstallDir, runmodeSuffix,
+          contentPackage("acs-aem-commons-ui.content{runmode}", "4.10.0-99_99-SNAPSHOT"),
+          contentPackage("aem-cms-author-replicationagents{runmode}",
+              dep("adobe/consulting:acs-aem-commons-ui.content{runmode}:4.10.0-99_99-SNAPSHOT")),
+          contentPackage("wcm-io-samples-sample-content{runmode}", "1.3.1-SNAPSHOT",
+              dep("wcm-io-samples:aem-cms-author-replicationagents{runmode}:1.3.1-SNAPSHOT")));
+    }
+
+    File containerDir = new File(appsDir, "container");
+    assertDirectories(containerDir, toInstallFolderNames("install", runmodeSuffixes));
+
+    for (String runmodeSuffix : runmodeSuffixes) {
+      File containerInstallDir = new File(containerDir, "install" + runmodeSuffix);
+      assertFiles(containerInstallDir, runmodeSuffix,
+          contentPackage("accesscontroltool-package{runmode}", "3.0.0-99_99-SNAPSHOT",
+              dep("adobe/consulting:acs-aem-commons-ui.apps{runmode}:4.10.0-99_99-SNAPSHOT")),
+          contentPackage("core.wcm.components.all{runmode}", "2.17.0-99_99-SNAPSHOT",
+              dep("Netcentric:accesscontroltool-oakindex-package{runmode}:3.0.0-99_99-SNAPSHOT")),
+          contentPackage("core.wcm.components.config{runmode}", "2.17.0-99_99-SNAPSHOT",
+              dep("Netcentric:accesscontroltool-oakindex-package{runmode}:3.0.0-99_99-SNAPSHOT")),
+          contentPackage("wcm-io-samples-aem-cms-config{runmode}",
+              dep("wcm-io-samples:aem-cms-system-config{runmode}:1.3.1-SNAPSHOT")),
+          contentPackage("wcm-io-samples-complete{runmode}", "1.3.1-SNAPSHOT",
+              dep("wcm-io-samples:wcm-io-samples-aem-cms-config{runmode}:1.3.1-SNAPSHOT")));
+    }
+  }
+
 }

--- a/tooling/conga-aem-maven-plugin/src/test/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilderPackageVersionModeTest.java
+++ b/tooling/conga-aem-maven-plugin/src/test/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilderPackageVersionModeTest.java
@@ -1,0 +1,211 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2022 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.devops.conga.plugins.aem.maven.allpackage;
+
+import static io.wcm.devops.conga.plugins.aem.maven.allpackage.AllPackageBuilderTest.toInstallFolderNames;
+import static io.wcm.devops.conga.plugins.aem.maven.allpackage.FileTestUtil.assertDirectories;
+import static io.wcm.devops.conga.plugins.aem.maven.allpackage.FileTestUtil.assertFiles;
+import static io.wcm.devops.conga.plugins.aem.maven.allpackage.FileTestUtil.contentPackage;
+import static io.wcm.devops.conga.plugins.aem.maven.allpackage.FileTestUtil.dep;
+import static io.wcm.devops.conga.plugins.aem.maven.allpackage.FileTestUtil.file;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.zeroturnaround.zip.ZipUtil;
+
+import io.wcm.devops.conga.plugins.aem.maven.AutoDependenciesMode;
+import io.wcm.devops.conga.plugins.aem.maven.PackageVersionMode;
+import io.wcm.devops.conga.plugins.aem.maven.model.InstallableFile;
+import io.wcm.devops.conga.plugins.aem.maven.model.ModelParser;
+
+class AllPackageBuilderPackageVersionModeTest {
+
+  private File nodeDir;
+  private File targetDir;
+  private File targetUnpackDir;
+
+  @BeforeEach
+  void setUp(TestInfo testInfo) throws IOException {
+    nodeDir = new File("src/test/resources/node/aem-author");
+    targetDir = new File("target/test-" + getClass().getSimpleName() + "_" + testInfo.getDisplayName());
+    targetUnpackDir = new File(targetDir, "unpack");
+    FileUtils.deleteDirectory(targetDir);
+    targetDir.mkdirs();
+    targetUnpackDir.mkdirs();
+  }
+
+  @Test
+  void testBuild_DEFAULT() throws Exception {
+    List<InstallableFile> files = new ModelParser(nodeDir).getInstallableFilesForNode();
+    List<String> runmodeSuffixes = Collections.singletonList(".author");
+    File targetFile = new File(targetDir, "all.zip");
+
+    AllPackageBuilder builder = new AllPackageBuilder(targetFile, "test-group", "test-pkg")
+        .autoDependenciesMode(AutoDependenciesMode.IMMUTABLE_MUTABLE_SEPARATE)
+        .version("99.99");
+    builder.add(files, Collections.emptySet());
+    assertTrue(builder.build(null));
+
+    ZipUtil.unpack(targetFile, targetUnpackDir);
+
+    File appsDir = new File(targetUnpackDir, "jcr_root/apps/test-group-test-pkg-packages");
+    assertDirectories(appsDir, "application", "content", "container");
+
+    File applicationDir = new File(appsDir, "application");
+    assertDirectories(applicationDir, toInstallFolderNames("install", runmodeSuffixes));
+
+    for (String runmodeSuffix : runmodeSuffixes) {
+      File applicationInstallDir = new File(applicationDir, "install" + runmodeSuffix);
+      assertFiles(applicationInstallDir, runmodeSuffix,
+          contentPackage("accesscontroltool-apps-package{runmode}", "3.0.0",
+              dep("adobe/consulting:acs-aem-commons-ui.apps{runmode}:4.10.0")),
+          contentPackage("accesscontroltool-oakindex-package{runmode}", "3.0.0",
+              dep("Netcentric:accesscontroltool-package{runmode}:3.0.0")),
+          contentPackage("core.wcm.components.content{runmode}", "2.17.0",
+              dep("day/cq60/product:cq-platform-content:1.3.248"),
+              dep("Netcentric:accesscontroltool-oakindex-package{runmode}:3.0.0")),
+          contentPackage("core.wcm.components.extensions.amp.content{runmode}", "2.17.0",
+              dep("Netcentric:accesscontroltool-oakindex-package{runmode}:3.0.0")),
+          contentPackage("acs-aem-commons-ui.apps{runmode}", "4.10.0",
+              dep("day/cq60/product:cq-content:6.3.64")),
+          contentPackage("aem-cms-system-config{runmode}",
+              dep("day/cq60/product:cq-ui-wcm-editor-content:1.1.224"),
+              dep("adobe/cq/product:cq-remotedam-client-ui-components:1.1.6"),
+              dep("adobe/cq60:core.wcm.components.all{runmode}:2.17.0")),
+          file("io.wcm.caconfig.editor-1.11.0.jar"),
+          file("io.wcm.wcm.ui.granite-1.9.2.jar"));
+    }
+
+    File contentDir = new File(appsDir, "content");
+    assertDirectories(contentDir, toInstallFolderNames("install", runmodeSuffixes));
+
+    for (String runmodeSuffix : runmodeSuffixes) {
+      File contentInstallDir = new File(contentDir, "install" + runmodeSuffix);
+      assertFiles(contentInstallDir, runmodeSuffix,
+          contentPackage("acs-aem-commons-ui.content{runmode}", "4.10.0"),
+          contentPackage("aem-cms-author-replicationagents{runmode}",
+              dep("adobe/consulting:acs-aem-commons-ui.content{runmode}:4.10.0")),
+          contentPackage("wcm-io-samples-sample-content{runmode}", "1.3.1-SNAPSHOT",
+              dep("wcm-io-samples:aem-cms-author-replicationagents{runmode}:1.3.1-SNAPSHOT")));
+    }
+
+    File containerDir = new File(appsDir, "container");
+    assertDirectories(containerDir, toInstallFolderNames("install", runmodeSuffixes));
+
+    for (String runmodeSuffix : runmodeSuffixes) {
+      File containerInstallDir = new File(containerDir, "install" + runmodeSuffix);
+      assertFiles(containerInstallDir, runmodeSuffix,
+          contentPackage("accesscontroltool-package{runmode}", "3.0.0",
+              dep("adobe/consulting:acs-aem-commons-ui.apps{runmode}:4.10.0")),
+          contentPackage("core.wcm.components.all{runmode}", "2.17.0",
+              dep("Netcentric:accesscontroltool-oakindex-package{runmode}:3.0.0")),
+          contentPackage("core.wcm.components.config{runmode}", "2.17.0",
+              dep("Netcentric:accesscontroltool-oakindex-package{runmode}:3.0.0")),
+          contentPackage("wcm-io-samples-aem-cms-config{runmode}",
+              dep("wcm-io-samples:aem-cms-system-config{runmode}:1.3.1-SNAPSHOT")),
+          contentPackage("wcm-io-samples-complete{runmode}", "1.3.1-SNAPSHOT",
+              dep("wcm-io-samples:wcm-io-samples-aem-cms-config{runmode}:1.3.1-SNAPSHOT")));
+    }
+  }
+
+  @Test
+  void testBuild_RELEASE_SUFFIX_VERSION() throws Exception {
+    List<InstallableFile> files = new ModelParser(nodeDir).getInstallableFilesForNode();
+    List<String> runmodeSuffixes = Collections.singletonList(".author");
+    File targetFile = new File(targetDir, "all.zip");
+
+    AllPackageBuilder builder = new AllPackageBuilder(targetFile, "test-group", "test-pkg")
+        .autoDependenciesMode(AutoDependenciesMode.IMMUTABLE_MUTABLE_SEPARATE)
+        .packageVersionMode(PackageVersionMode.RELEASE_SUFFIX_VERSION)
+        .version("99.99");
+    builder.add(files, Collections.emptySet());
+    assertTrue(builder.build(null));
+
+    ZipUtil.unpack(targetFile, targetUnpackDir);
+
+    File appsDir = new File(targetUnpackDir, "jcr_root/apps/test-group-test-pkg-packages");
+    assertDirectories(appsDir, "application", "content", "container");
+
+    File applicationDir = new File(appsDir, "application");
+    assertDirectories(applicationDir, toInstallFolderNames("install", runmodeSuffixes));
+
+    for (String runmodeSuffix : runmodeSuffixes) {
+      File applicationInstallDir = new File(applicationDir, "install" + runmodeSuffix);
+      assertFiles(applicationInstallDir, runmodeSuffix,
+          contentPackage("accesscontroltool-apps-package{runmode}", "3.0.0-99_99",
+              dep("adobe/consulting:acs-aem-commons-ui.apps{runmode}:4.10.0-99_99")),
+          contentPackage("accesscontroltool-oakindex-package{runmode}", "3.0.0-99_99",
+              dep("Netcentric:accesscontroltool-package{runmode}:3.0.0-99_99")),
+          contentPackage("core.wcm.components.content{runmode}", "2.17.0-99_99",
+              dep("day/cq60/product:cq-platform-content:1.3.248"),
+              dep("Netcentric:accesscontroltool-oakindex-package{runmode}:3.0.0-99_99")),
+          contentPackage("core.wcm.components.extensions.amp.content{runmode}", "2.17.0-99_99",
+              dep("Netcentric:accesscontroltool-oakindex-package{runmode}:3.0.0-99_99")),
+          contentPackage("acs-aem-commons-ui.apps{runmode}", "4.10.0-99_99",
+              dep("day/cq60/product:cq-content:6.3.64")),
+          contentPackage("aem-cms-system-config{runmode}",
+              dep("day/cq60/product:cq-ui-wcm-editor-content:1.1.224"),
+              dep("adobe/cq/product:cq-remotedam-client-ui-components:1.1.6"),
+              dep("adobe/cq60:core.wcm.components.all{runmode}:2.17.0-99_99")),
+          file("io.wcm.caconfig.editor-1.11.0.jar"),
+          file("io.wcm.wcm.ui.granite-1.9.2.jar"));
+    }
+
+    File contentDir = new File(appsDir, "content");
+    assertDirectories(contentDir, toInstallFolderNames("install", runmodeSuffixes));
+
+    for (String runmodeSuffix : runmodeSuffixes) {
+      File contentInstallDir = new File(contentDir, "install" + runmodeSuffix);
+      assertFiles(contentInstallDir, runmodeSuffix,
+          contentPackage("acs-aem-commons-ui.content{runmode}", "4.10.0-99_99"),
+          contentPackage("aem-cms-author-replicationagents{runmode}",
+              dep("adobe/consulting:acs-aem-commons-ui.content{runmode}:4.10.0-99_99")),
+          contentPackage("wcm-io-samples-sample-content{runmode}", "1.3.1-SNAPSHOT",
+              dep("wcm-io-samples:aem-cms-author-replicationagents{runmode}:1.3.1-SNAPSHOT")));
+    }
+
+    File containerDir = new File(appsDir, "container");
+    assertDirectories(containerDir, toInstallFolderNames("install", runmodeSuffixes));
+
+    for (String runmodeSuffix : runmodeSuffixes) {
+      File containerInstallDir = new File(containerDir, "install" + runmodeSuffix);
+      assertFiles(containerInstallDir, runmodeSuffix,
+          contentPackage("accesscontroltool-package{runmode}", "3.0.0-99_99",
+              dep("adobe/consulting:acs-aem-commons-ui.apps{runmode}:4.10.0-99_99")),
+          contentPackage("core.wcm.components.all{runmode}", "2.17.0-99_99",
+              dep("Netcentric:accesscontroltool-oakindex-package{runmode}:3.0.0-99_99")),
+          contentPackage("core.wcm.components.config{runmode}", "2.17.0-99_99",
+              dep("Netcentric:accesscontroltool-oakindex-package{runmode}:3.0.0-99_99")),
+          contentPackage("wcm-io-samples-aem-cms-config{runmode}",
+              dep("wcm-io-samples:aem-cms-system-config{runmode}:1.3.1-SNAPSHOT")),
+          contentPackage("wcm-io-samples-complete{runmode}", "1.3.1-SNAPSHOT",
+              dep("wcm-io-samples:wcm-io-samples-aem-cms-config{runmode}:1.3.1-SNAPSHOT")));
+    }
+  }
+
+}

--- a/tooling/conga-aem-maven-plugin/src/test/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilderTest.java
+++ b/tooling/conga-aem-maven-plugin/src/test/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilderTest.java
@@ -352,7 +352,7 @@ class AllPackageBuilderTest {
     }
   }
 
-  private String[] toInstallFolderNames(String baseName, List<String> runmodeSuffixes) {
+  static String[] toInstallFolderNames(String baseName, List<String> runmodeSuffixes) {
     return runmodeSuffixes.stream()
         .map(suffix -> baseName + suffix)
         .toArray(size -> new String[size]);


### PR DESCRIPTION
to support deploying "all" packages via cloud manager to AMS-managed AEM 6.5 instances, add a flag that automatically adds a version suffix to all packages with release number. otherwise it may happen due to different order of package dependency that a packages with same version is binary different from a previously installed one.