### PR TITLE
[59] Fix content package dependency rewriting when auto-dependencies-mode is OFF

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -30,6 +30,9 @@
       <action type="update" dev="sseifert">
         Eliminate usage of Guava.
       </action>
+      <action type="fix" dev="cnagel">
+        conga-aem-maven-plugin: Fix content package dependency rewriting when auto-dependencies-mode is OFF.
+      </action>
     </release>
 
     <release version="2.19.4" date="2023-03-27">

--- a/changes.xml
+++ b/changes.xml
@@ -30,8 +30,8 @@
       <action type="update" dev="sseifert">
         Eliminate usage of Guava.
       </action>
-      <action type="fix" dev="cnagel">
-        conga-aem-maven-plugin: Fix content package dependency rewriting when auto-dependencies-mode is OFF.
+      <action type="fix" dev="cnagel" issue="59">
+        conga-aem-maven-plugin: Fix content package dependency rewriting when autoDependenciesMode=OFF.
       </action>
     </release>
 

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilder.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilder.java
@@ -43,6 +43,7 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -598,7 +599,7 @@ public final class AllPackageBuilder {
                 if (autoDependenciesMode == AutoDependenciesMode.OFF) {
                   dependencyFile = null;
                 }
-                updateDependencies(props, dependencyFile, environmentRunMode, allPackagesFromFileSets);
+                updateDependencies(pkg, props, dependencyFile, environmentRunMode, allPackagesFromFileSets);
 
                 // if package type is missing in package properties, put in the type defined in model
                 String packageType = pkg.getPackageType();
@@ -678,28 +679,27 @@ public final class AllPackageBuilder {
 
   /**
    * Add dependency information to dependencies string in properties (if it does not exist already).
+   * @param pkg Current content package
    * @param props Properties
    * @param dependencyFile Dependency package
    * @param allPackagesFromFileSets Set with all packages from all file sets as dependency instances
    */
-  private void updateDependencies(Properties props, ContentPackageFile dependencyFile, String environmentRunMode,
-      Set<Dependency> allPackagesFromFileSets) {
+  private void updateDependencies(ContentPackageFile pkg, Properties props, ContentPackageFile dependencyFile,
+      String environmentRunMode, Set<Dependency> allPackagesFromFileSets) {
     String[] existingDepsStrings = StringUtils.split(props.getProperty(NAME_DEPENDENCIES), ",");
     Dependency[] existingDeps = null;
     if (existingDepsStrings != null && existingDepsStrings.length > 0) {
       existingDeps = Dependency.fromString(existingDepsStrings);
     }
     if (existingDeps != null) {
-      existingDeps = removeReferencesToManagedPackages(existingDeps, allPackagesFromFileSets);
+      existingDeps = autoDependenciesMode == AutoDependenciesMode.OFF
+          ? rewriteReferencesToManagedPackages(pkg, environmentRunMode, allPackagesFromFileSets, existingDeps)
+          : removeReferencesToManagedPackages(existingDeps, allPackagesFromFileSets);
     }
 
     Dependency[] deps;
     if (dependencyFile != null) {
-      String runModeSuffix = buildRunModeSuffix(dependencyFile, environmentRunMode);
-      String dependencyVersion = dependencyFile.getVersion() + buildVersionSuffix(dependencyFile, true);
-      Dependency newDependency = new Dependency(dependencyFile.getGroup(),
-          dependencyFile.getName() + runModeSuffix,
-          VersionRange.fromString(dependencyVersion));
+      Dependency newDependency = createDependencyFromContentPackageFile(dependencyFile, environmentRunMode);
       deps = addDependency(existingDeps, newDependency);
     }
     else {
@@ -710,6 +710,15 @@ public final class AllPackageBuilder {
       String dependenciesString = Dependency.toString(deps);
       props.put(NAME_DEPENDENCIES, dependenciesString);
     }
+  }
+
+  private @NotNull Dependency createDependencyFromContentPackageFile(@NotNull ContentPackageFile dependencyFile,
+      @NotNull String environmentRunMode) {
+    String runModeSuffix = buildRunModeSuffix(dependencyFile, environmentRunMode);
+    String dependencyVersion = dependencyFile.getVersion() + buildVersionSuffix(dependencyFile, true);
+    return new Dependency(dependencyFile.getGroup(),
+        dependencyFile.getName() + runModeSuffix,
+        VersionRange.fromString(dependencyVersion));
   }
 
   private static Dependency[] addDependency(Dependency[] existingDeps, Dependency newDependency) {
@@ -734,6 +743,55 @@ public final class AllPackageBuilder {
     }
     String suffixedVersion = pkg.getVersion() + buildVersionSuffix(pkg, true);
     props.put(NAME_VERSION, suffixedVersion);
+  }
+
+  private @NotNull Dependency[] rewriteReferencesToManagedPackages(@NotNull ContentPackageFile pkg,
+      @NotNull String environmentRunMode, @NotNull Set<Dependency> allPackagesFromFileSets, @NotNull Dependency[] deps) {
+    return Arrays.stream(deps)
+        .map(dep -> rewriteReferenceIfDependencyIsManagedPackage(pkg, environmentRunMode, allPackagesFromFileSets, dep))
+        .toArray(Dependency[]::new);
+  }
+
+  private @NotNull Dependency rewriteReferenceIfDependencyIsManagedPackage(@NotNull ContentPackageFile pkg,
+      @NotNull String environmentRunMode, @NotNull Set<Dependency> allPackagesFromFileSets, @NotNull Dependency dep) {
+    // not a managed package, return as is
+    if (!allPackagesFromFileSets.contains(dep)) {
+      return dep;
+    }
+    return findContentPackageFileForDependency(pkg, dep)
+        // found a content package file for the dependency, rewrite the dependency
+        .map(contentPackageFile -> createDependencyFromContentPackageFile(contentPackageFile, environmentRunMode))
+        // found no content package file for the dependency, use current run mode suffix
+        .orElseGet(() -> createDependencyWithCurrentPackageRunModeSuffix(pkg, environmentRunMode, dep));
+  }
+
+  private @NotNull Optional<ContentPackageFile> findContentPackageFileForDependency(@NotNull ContentPackageFile pkg,
+      @NotNull Dependency dep) {
+    // look for content package in all file sets
+    return contentPackageFileSets.stream()
+            // prefer file set which contains the current package to use current run mode
+            .sorted((fileSet1, fileSet2) -> sortFileSetsContainingPackageFirst(pkg, fileSet1, fileSet2))
+            .flatMap(fileSet -> fileSet.getFiles().stream())
+            .filter(contentPackageFile -> isContentPackageForDependency(contentPackageFile, dep))
+            .findFirst();
+  }
+
+  private int sortFileSetsContainingPackageFirst(@NotNull ContentPackageFile pkg,
+      @NotNull ContentPackageFileSet fileSet1, @NotNull ContentPackageFileSet fileSet2) {
+    int fileSet1ContainsPackage = fileSet1.getFiles().contains(pkg) ? 1 : 0;
+    int fileSet2ContainsPackage = fileSet2.getFiles().contains(pkg) ? 1 : 0;
+    return fileSet2ContainsPackage - fileSet1ContainsPackage;
+  }
+
+  private boolean isContentPackageForDependency(@NotNull ContentPackageFile contentPackageFile, @NotNull Dependency dep) {
+    return contentPackageFile.getGroup().equals(dep.getGroup())
+            && contentPackageFile.getName().equals(dep.getName());
+  }
+
+  private @NotNull Dependency createDependencyWithCurrentPackageRunModeSuffix(@NotNull ContentPackageFile pkg,
+      @NotNull String environmentRunMode, @NotNull Dependency dep) {
+    String runModeSuffix = buildRunModeSuffix(pkg, environmentRunMode);
+    return new Dependency(dep.getGroup(), dep.getName() + runModeSuffix, dep.getRange());
   }
 
   /**

--- a/tooling/conga-aem-maven-plugin/src/test/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilderAuthorPublishTest.java
+++ b/tooling/conga-aem-maven-plugin/src/test/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilderAuthorPublishTest.java
@@ -85,7 +85,8 @@ class AllPackageBuilderAuthorPublishTest {
         contentPackage("accesscontroltool-oakindex-package{runmode}", "3.0.0"),
         contentPackage("core.wcm.components.content{runmode}", "2.17.0",
             dep("day/cq60/product:cq-platform-content:1.3.248")),
-        contentPackage("core.wcm.components.extensions.amp.content{runmode}", "2.17.0"),
+        contentPackage("core.wcm.components.extensions.amp.content{runmode}", "2.17.0",
+            dep("adobe/cq60:core.wcm.components.content{runmode}:2.17.0")),
         contentPackage("acs-aem-commons-ui.apps{runmode}", "4.10.0",
             dep("day/cq60/product:cq-content:6.3.64")),
         contentPackage("aem-cms-system-config{runmode}",
@@ -97,7 +98,8 @@ class AllPackageBuilderAuthorPublishTest {
     assertFiles(applicationInstallDirPublish, ".publish",
         contentPackage("core.wcm.components.content{runmode}", "2.17.0",
             dep("day/cq60/product:cq-platform-content:1.3.248")),
-        contentPackage("core.wcm.components.extensions.amp.content{runmode}", "2.17.0"),
+        contentPackage("core.wcm.components.extensions.amp.content{runmode}", "2.17.0",
+            dep("adobe/cq60:core.wcm.components.content{runmode}:2.17.0")),
         contentPackage("acs-aem-commons-ui.apps{runmode}", "4.10.0",
             dep("day/cq60/product:cq-content:6.3.64")),
         contentPackage("aem-cms-system-config{runmode}",
@@ -110,12 +112,14 @@ class AllPackageBuilderAuthorPublishTest {
 
     File contentInstallDirAuthor = new File(contentDir, "install.author");
     assertFiles(contentInstallDirAuthor, ".author",
-        contentPackage("acs-aem-commons-ui.content{runmode}", "4.10.0"),
+        contentPackage("acs-aem-commons-ui.content{runmode}", "4.10.0",
+            dep("adobe/consulting:acs-aem-commons-ui.apps{runmode}:4.10.0")),
         contentPackage("aem-cms-author-replicationagents{runmode}"),
         contentPackage("wcm-io-samples-sample-content{runmode}", "1.3.1-SNAPSHOT"));
     File contentInstallDirPublish = new File(contentDir, "install.publish");
     assertFiles(contentInstallDirPublish, ".publish",
-        contentPackage("acs-aem-commons-ui.content{runmode}", "4.10.0"),
+        contentPackage("acs-aem-commons-ui.content{runmode}", "4.10.0",
+            dep("adobe/consulting:acs-aem-commons-ui.apps{runmode}:4.10.0")),
         contentPackage("wcm-io-samples-sample-content{runmode}", "1.3.1-SNAPSHOT"),
         contentPackage("aem-cms-publish-sling-mapping{runmode}"));
 
@@ -161,7 +165,8 @@ class AllPackageBuilderAuthorPublishTest {
     assertFiles(applicationInstallDir, "",
         contentPackage("core.wcm.components.content", "2.17.0",
             dep("day/cq60/product:cq-platform-content:1.3.248")),
-        contentPackage("core.wcm.components.extensions.amp.content", "2.17.0"),
+        contentPackage("core.wcm.components.extensions.amp.content", "2.17.0",
+            dep("adobe/cq60:core.wcm.components.content:2.17.0")),
         contentPackage("acs-aem-commons-ui.apps", "4.10.0",
             dep("day/cq60/product:cq-content:6.3.64")),
         contentPackage("aem-cms-system-config",
@@ -179,7 +184,8 @@ class AllPackageBuilderAuthorPublishTest {
 
     File contentInstallDir = new File(contentDir, "install");
     assertFiles(contentInstallDir, "",
-        contentPackage("acs-aem-commons-ui.content", "4.10.0"),
+        contentPackage("acs-aem-commons-ui.content", "4.10.0",
+            dep("adobe/consulting:acs-aem-commons-ui.apps:4.10.0")),
         contentPackage("wcm-io-samples-sample-content", "1.3.1-SNAPSHOT"));
     File contentInstallDirAuthor = new File(contentDir, "install.author");
     assertFiles(contentInstallDirAuthor, ".author",

--- a/tooling/conga-aem-maven-plugin/src/test/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilderTest.java
+++ b/tooling/conga-aem-maven-plugin/src/test/java/io/wcm/devops/conga/plugins/aem/maven/allpackage/AllPackageBuilderTest.java
@@ -96,7 +96,8 @@ class AllPackageBuilderTest {
           contentPackage("accesscontroltool-oakindex-package{runmode}", "3.0.0"),
           contentPackage("core.wcm.components.content{runmode}", "2.17.0",
               dep("day/cq60/product:cq-platform-content:1.3.248")),
-          contentPackage("core.wcm.components.extensions.amp.content{runmode}", "2.17.0"),
+          contentPackage("core.wcm.components.extensions.amp.content{runmode}", "2.17.0",
+              dep("adobe/cq60:core.wcm.components.content{runmode}:2.17.0")),
           contentPackage("acs-aem-commons-ui.apps{runmode}", "4.10.0",
               dep("day/cq60/product:cq-content:6.3.64")),
           contentPackage("aem-cms-system-config{runmode}",
@@ -112,7 +113,8 @@ class AllPackageBuilderTest {
     for (String runmodeSuffix : runmodeSuffixes) {
       File contentInstallDir = new File(contentDir, "install" + runmodeSuffix);
       assertFiles(contentInstallDir, runmodeSuffix,
-          contentPackage("acs-aem-commons-ui.content{runmode}", "4.10.0"),
+          contentPackage("acs-aem-commons-ui.content{runmode}", "4.10.0",
+              dep("adobe/consulting:acs-aem-commons-ui.apps{runmode}:4.10.0")),
           contentPackage("aem-cms-author-replicationagents{runmode}"),
           contentPackage("wcm-io-samples-sample-content{runmode}", "1.3.1-SNAPSHOT"));
     }


### PR DESCRIPTION
When `autoDependenciesMode` is set to `OFF`, all dependencies to managed content packages get lost.

Instead, the dependencies should stay. Furthermore, it needs to rewrite them (e.g. run mode suffix).

Fixes #59 