### PR TITLE
Increase SnakeYAML codepoint limit to 64MB (from default 3MB)

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 https://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="2.19.8" date="not released">
+      <action type="fix" dev="trichter">
+        Increase SnakeYAML codepoint limit to 64MB (from default 3MB).
+      </action>
+    </release>
+
     <release version="2.19.6" date="2023-08-31">
       <action type="update" dev="sseifert">
         Switch to latest Maven APIs to handle build output timestamp.

--- a/changes.xml
+++ b/changes.xml
@@ -24,7 +24,7 @@
   <body>
 
     <release version="2.19.8" date="not released">
-      <action type="fix" dev="trichter">
+      <action type="fix" dev="trichter" issue="73">
         Increase SnakeYAML codepoint limit to 64MB (from default 3MB).
       </action>
     </release>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -57,12 +57,12 @@
       <dependency>
         <groupId>io.wcm.devops.conga</groupId>
         <artifactId>io.wcm.devops.conga.generator</artifactId>
-        <version>1.16.2</version>
+        <version>1.16.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.wcm.devops.conga</groupId>
         <artifactId>conga-maven-plugin</artifactId>
-        <version>1.16.2</version>
+        <version>1.16.3-SNAPSHOT</version>
       </dependency>
   
       <dependency>
@@ -74,7 +74,7 @@
       <dependency>
         <groupId>io.wcm.devops.conga.plugins</groupId>
         <artifactId>io.wcm.devops.conga.plugins.ansible</artifactId>
-        <version>1.4.0</version>
+        <version>1.4.5-SNAPSHOT</version>
       </dependency>
   
       <dependency>

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/model/YamlUtil.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/model/YamlUtil.java
@@ -21,7 +21,6 @@ package io.wcm.devops.conga.plugins.aem.maven.model;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/model/YamlUtil.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/model/YamlUtil.java
@@ -47,7 +47,7 @@ final class YamlUtil {
         .logger(log);
 
     // apply YAML plugins for modifying YAML constructor
-    Constructor constructor = new Constructor(new LoaderOptions());
+    Constructor constructor = new Constructor(io.wcm.devops.conga.model.util.YamlUtil.createLoaderOptions());
     YamlConstructorContext context = new YamlConstructorContext()
         .pluginContextOptions(options)
         .yamlConstructor(constructor);


### PR DESCRIPTION
With https://github.com/wcm-io-devops/conga/pull/47 the codepoint limit of SnakeYAML was increased to 64MB in the conga model generator.
But the YamlUtil of the conga aem maven plugin was still using the default limit.
With this PR we are now using the new introduced io.wcm.devops.conga.model.util.YamlUtil.createLoaderOptions()