### PR TITLE
CRX Package Manager Upload: Add system ready check after deployment

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,13 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+    <release version="2.22.0" date="not released">
+      <action type="add" dev="sseifert">
+        CRX Package Manager Upload: Add system ready check after deployment (enabled by default, can be disabled).
+        It only has an effect when deploying to AEMaaCS instances. Default responses from AEM 6.5 and 6.6 instances are accepted as valid.
+      </action>
+    </release>
+
     <release version="2.21.0" date="2025-06-18">
       <action type="add" dev="sseifert" issue="179">
         Content Package Post Processors: Add option "dependencyChainIgnore" to ignore a content package in the dependency chain, i.e. it does not play a role for this package in which order it is deployed compared to other packages.

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -57,12 +57,12 @@
       <dependency>
         <groupId>io.wcm.devops.conga</groupId>
         <artifactId>io.wcm.devops.conga.generator</artifactId>
-        <version>1.17.4</version>
+        <version>1.17.5-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.wcm.devops.conga</groupId>
         <artifactId>conga-maven-plugin</artifactId>
-        <version>1.17.4</version>
+        <version>1.17.5-SNAPSHOT</version>
       </dependency>
   
       <dependency>
@@ -85,7 +85,7 @@
       <dependency>
         <groupId>io.wcm.tooling.commons</groupId>
         <artifactId>io.wcm.tooling.commons.crx-packmgr-helper</artifactId>
-        <version>2.2.0</version>
+        <version>2.2.1-SNAPSHOT</version>
       </dependency>
 
       <dependency>

--- a/tooling/conga-aem-maven-plugin/src/it/example/pom.xml
+++ b/tooling/conga-aem-maven-plugin/src/it/example/pom.xml
@@ -78,7 +78,7 @@
       <plugin>
         <groupId>io.wcm.devops.conga</groupId>
         <artifactId>conga-maven-plugin</artifactId>
-        <version>1.17.4</version>
+        <version>1.17.5-SNAPSHOT</version>
         <extensions>true</extensions>
         <dependencies>
 

--- a/tooling/conga-aem-maven-plugin/src/it/mixed-no-package-type/pom.xml
+++ b/tooling/conga-aem-maven-plugin/src/it/mixed-no-package-type/pom.xml
@@ -69,7 +69,7 @@
       <plugin>
         <groupId>io.wcm.devops.conga</groupId>
         <artifactId>conga-maven-plugin</artifactId>
-        <version>1.17.4</version>
+        <version>1.17.5-SNAPSHOT</version>
         <extensions>true</extensions>
         <dependencies>
 

--- a/tooling/conga-aem-maven-plugin/src/it/wcmio-archetype-aem65/parent/pom.xml
+++ b/tooling/conga-aem-maven-plugin/src/it/wcmio-archetype-aem65/parent/pom.xml
@@ -321,7 +321,7 @@
         <plugin>
           <groupId>io.wcm.devops.conga</groupId>
           <artifactId>conga-maven-plugin</artifactId>
-          <version>1.17.4</version>
+          <version>1.17.5-SNAPSHOT</version>
           <dependencies>
             <dependency>
               <groupId>io.wcm.devops.conga.plugins</groupId>

--- a/tooling/conga-aem-maven-plugin/src/it/wcmio-archetype-cloud/parent/pom.xml
+++ b/tooling/conga-aem-maven-plugin/src/it/wcmio-archetype-cloud/parent/pom.xml
@@ -268,7 +268,7 @@
         <plugin>
           <groupId>io.wcm.devops.conga</groupId>
           <artifactId>conga-maven-plugin</artifactId>
-          <version>1.17.4</version>
+          <version>1.17.5-SNAPSHOT</version>
           <dependencies>
             <dependency>
               <groupId>io.wcm.devops.conga.plugins</groupId>

--- a/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/AbstractContentPackageMojo.java
+++ b/tooling/conga-aem-maven-plugin/src/main/java/io/wcm/devops/conga/plugins/aem/maven/AbstractContentPackageMojo.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -191,6 +191,28 @@ abstract class AbstractContentPackageMojo extends AbstractMojo {
   private String[] bundleStatusWhitelistBundleNames;
 
   /**
+   * System ready JSON URL. If an URL is configured the systemready status of the target instance is checked
+   * after installing finishing the upload. This works only for AEMaaCS SDK instances.
+   *
+   * <p>
+   * Expected is an URL like: http://localhost:4502/systemready
+   * </p>
+   *
+   * <p>
+   * If the URL is not set it is derived from serviceURL. If set to "-" the status check is disabled.
+   * </p>
+   */
+  @Parameter(property = "vault.systemReadyURL", required = false)
+  private String systemReadyURL;
+
+  /**
+   * Number of seconds to wait as maximum for a positive system ready check.
+   * If this limit is reached and the system ready is still not positive the install of the package proceeds anyway.
+   */
+  @Parameter(property = "vault.systemReadyWaitLimitSec", defaultValue = "30")
+  private int systemReadyWaitLimitSec;
+
+  /**
    * If set to true also self-signed certificates are accepted.
    */
   @Parameter(property = "vault.relaxedSSLCheck", defaultValue = "false")
@@ -241,6 +263,8 @@ abstract class AbstractContentPackageMojo extends AbstractMojo {
     props.setBundleStatusWaitLimitSec(this.bundleStatusWaitLimit);
     props.setBundleStatusBlacklistBundleNames(List.of(this.bundleStatusBlacklistBundleNames));
     props.setBundleStatusWhitelistBundleNames(List.of(this.bundleStatusWhitelistBundleNames));
+    props.setSystemReadyUrl(buildSystemReadyUrl());
+    props.setSystemReadyWaitLimitSec(this.systemReadyWaitLimitSec);
     props.setPackageManagerInstallStatusURL(buildPackageManagerInstallStatusUrl());
     props.setPackageManagerInstallStatusWaitLimitSec(this.packageManagerInstallStatusWaitLimit);
     props.setRelaxedSSLCheck(this.relaxedSSLCheck);
@@ -268,7 +292,7 @@ abstract class AbstractContentPackageMojo extends AbstractMojo {
   }
 
   private String buildBundleStatusUrl() throws MojoExecutionException {
-    if (StringUtils.equals(this.bundleStatusURL, "-")) {
+    if (Strings.CS.equals(this.bundleStatusURL, "-")) {
       return null;
     }
     if (this.bundleStatusURL != null) {
@@ -279,8 +303,20 @@ abstract class AbstractContentPackageMojo extends AbstractMojo {
     return baseUrl + "/system/console/bundles/.json";
   }
 
+  private String buildSystemReadyUrl() throws MojoExecutionException {
+    if (Strings.CS.equals(this.systemReadyURL, "-")) {
+      return null;
+    }
+    if (this.systemReadyURL != null) {
+      return this.systemReadyURL;
+    }
+    // if not set use hostname from serviceURL and add default path to bundle status
+    String baseUrl = VendorInstallerFactory.getBaseUrl(buildPackageManagerUrl());
+    return baseUrl + "/systemready";
+  }
+
   private String buildPackageManagerInstallStatusUrl() throws MojoExecutionException {
-    if (StringUtils.equals(this.packageManagerInstallStatusURL, "-")
+    if (Strings.CS.equals(this.packageManagerInstallStatusURL, "-")
         || VendorInstallerFactory.identify(this.serviceURL) != Service.CRX) {
       return null;
     }


### PR DESCRIPTION
* Add system ready check after deployment (enabled by default, can be disabled).
* It only has an effect when deploying to AEMaaCS instances. Default responses from AEM 6.5 and 6.6 instances are accepted as valid.

